### PR TITLE
Fix viewport for iPhone 5

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
         <meta name='HandheldFriendly' content='true'>
         <meta name='apple-mobile-web-app-capable' content='yes'>
         <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no'>
+        <meta name='viewport' content='initial-scale=1.0, maximum-scale=1.0, user-scalable=no' media='(device-height: 568px)'>
         
         <title>Food Trucks of Downtown Las Vegas</title>
         <meta name='description' content='App for officially designated mobile food vendor parking spots in Downtown Las Vegas. Find out when your favorite food trucks are downtown!'>


### PR DESCRIPTION
On my iPhone, when I saved the app to the home screen and opened it, it looked like this:
![ios simulator screen shot jul 15 2013 11 52 26 am](https://f.cloud.github.com/assets/173440/799992/3b07d338-ed80-11e2-8a3e-94e4f7beaaa9.png)
Notice the two ugly black bars? I did too.

With this change, it looks like this:
![ios simulator screen shot jul 15 2013 11 52 56 am](https://f.cloud.github.com/assets/173440/799995/4758327c-ed80-11e2-8fbd-83d94065482e.png)

Yay! I used [this technique](http://stackoverflow.com/a/13769323) to fix the bug.
